### PR TITLE
Upgrade Glide Version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ dependencies {
 
     implementation project(':redirectglide')
 
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    kapt 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    kapt 'com.github.bumptech.glide:compiler:4.11.0'
 
     implementation 'com.google.code.gson:gson:2.8.6'
 

--- a/redirectglide/build.gradle
+++ b/redirectglide/build.gradle
@@ -30,8 +30,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    kapt 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    kapt 'com.github.bumptech.glide:compiler:4.11.0'
     kapt 'androidx.annotation:annotation:1.1.0'
 
     implementation 'com.squareup.okhttp3:okhttp:4.2.2'


### PR DESCRIPTION
This PR fixes the #5 issues.
It is because the glide compiler plugin generates an incompatible version of `GeneratedAppGlideModuleImpl` when the lib and the app use different version of Glide.